### PR TITLE
Definitions: detect pOOWX/dvXlsc wrapper, exclude AIO render targets

### DIFF
--- a/src/Parser/Evaluated/MobileNaturalParser.php
+++ b/src/Parser/Evaluated/MobileNaturalParser.php
@@ -180,6 +180,7 @@ class MobileNaturalParser extends AbstractParser
             @jscontroller='U6XW6' or
             contains(@class, 'lr_container wDYxhc yc7KLc') or
             contains(@class, 'lr_container yc7KLc mBNN3d') or
+            @jsname='dvXlsc' or
             @jsname='MGJTwe' or
             @data-attrid='SupercatRecipeClusterTitle' or
             contains(@class, 'kp-wholepage') or

--- a/src/Parser/Evaluated/NaturalParser.php
+++ b/src/Parser/Evaluated/NaturalParser.php
@@ -192,6 +192,7 @@ class NaturalParser extends AbstractParser
             @class='Qq3Lb' or
             @class='xpdopen' or
             contains(@class, 'lr_container yc7KLc mBNN3d') or
+            @jsname='dvXlsc' or
             contains(@class, 'LQQ1Bd') or
             @class='BNeawe DwrKqd' or
             contains(@class, 'CH6Bmd') or

--- a/src/Parser/Evaluated/Rule/Natural/Definitions.php
+++ b/src/Parser/Evaluated/Rule/Natural/Definitions.php
@@ -25,6 +25,20 @@ class Definitions implements \Serps\SearchEngine\Google\Parser\ParsingRuleInterf
             return self::RULE_MATCH_MATCHED;
         }
 
+        if (!empty($class) && strpos($class, 'pOOWX') !== false
+            && $node->getAttribute('jsname') === 'dvXlsc'
+        ) {
+            // The pOOWX/dvXlsc wrapper is also reused as the AIO render target.
+            // Reject if any ancestor matches AIO container markers.
+            $aioAncestor = $dom->getXpath()->query(
+                'ancestor::*[contains(concat(" ", normalize-space(@class), " "), " YzCcne ")'
+                . ' or @data-attnms or @data-lfid]',
+                $node
+            );
+            if ($aioAncestor->length === 0) {
+                return self::RULE_MATCH_MATCHED;
+            }
+        }
 
         return self::RULE_MATCH_NOMATCH;
     }

--- a/src/Parser/Evaluated/Rule/Natural/DefinitionsMobile.php
+++ b/src/Parser/Evaluated/Rule/Natural/DefinitionsMobile.php
@@ -26,6 +26,21 @@ class DefinitionsMobile implements \Serps\SearchEngine\Google\Parser\ParsingRule
             return self::RULE_MATCH_MATCHED;
         }
 
+        if (!empty($class) && strpos($class, 'pOOWX') !== false
+            && $node->getAttribute('jsname') === 'dvXlsc'
+        ) {
+            // The pOOWX/dvXlsc wrapper is also reused as the AIO render target.
+            // Reject if any ancestor matches AIO container markers.
+            $aioAncestor = $dom->getXpath()->query(
+                'ancestor::*[contains(concat(" ", normalize-space(@class), " "), " YzCcne ")'
+                . ' or @data-attnms or @data-lfid]',
+                $node
+            );
+            if ($aioAncestor->length === 0) {
+                return self::RULE_MATCH_MATCHED;
+            }
+        }
+
         return self::RULE_MATCH_NOMATCH;
     }
 


### PR DESCRIPTION
## Summary

Re-introduces the `pOOWX`/`dvXlsc` Definitions detection that landed in 20a4eaf and was reverted in 9cb211b — this time guarded against AI Overview (AIO) false-positives.

## Why the original revert

Google reuses `<div jsname="dvXlsc" class="pOOWX">` as a generic Lazy Frame render target, including for AIO content. The unconditional match in 20a4eaf misclassified every AIO container as a Definitions box.

Counter-example was a `compare the market` mobile UK SERP — pure AIO content, no Definitions box — but the rule fired and tagged it as `DEFINITIONS_MOBILE`.

## Fix

Keep the new match branch but require the candidate node to have **no ancestor** carrying AIO container markers:

- `class~="YzCcne"` (AIO module container)
- `@data-attnms` (AIO Lazy Frame attribute)
- `@data-lfid` (AIO Lazy Frame ID)

These attributes are stable across the cached samples I probed and cover both shown-AIO and "AI Overview not available" placeholder variants.

## Verification

Probed cached mobile UK SERPs (2026-04-28): `cohabiting meaning`, `mortgage`, `house mortgage`, `what is an isa`. Every one of them has a `dvXlsc/pOOWX` node, and in every case the node sits inside an AIO container (markers above all present 6000 chars above).

PHP test on `DefinitionsMobile::match()` against the parsed DOM:

| SERP | Before patch | After patch |
|---|---|---|
| `cohabiting meaning` | `MATCHED` (false-positive) | `NOMATCH` ✅ |
| `mortgage` | `MATCHED` (false-positive) | `NOMATCH` ✅ |

**Caveat:** I couldn't locate a real Definitions sample using the new wrapper outside an AIO container in the monse cache. If those exist in the wild they'd still be matched here; if not, the new branch is a no-op on current SERPs and `lr_container` continues to handle the cases that remain. Either way it's a strict improvement over 20a4eaf — the rule no longer fires false-positives, and it'll start firing automatically if Google ships a non-AIO Definitions box using these classes.

## Test plan

- [x] PHP syntax check (4 files)
- [x] `DefinitionsMobile::match()` returns `NOMATCH` for AIO containers (verified above)
- [ ] Reviewer check: anything I missed re: AIO marker stability or other rules potentially clashing on the new xpath candidate