### PR TITLE
fix(stocks_box): detect via price quote (data-attrid='Price'), not stale 'Company Name' span

### DIFF
--- a/src/Parser/Evaluated/Rule/Natural/StocksBox.php
+++ b/src/Parser/Evaluated/Rule/Natural/StocksBox.php
@@ -15,7 +15,13 @@ class StocksBox implements \Serps\SearchEngine\Google\Parser\ParsingRuleInterfac
 
     public function match(GoogleDom $dom, \Serps\Core\Dom\DomElement $node)
     {
-        if ($node->getAttribute('class') == 'wDYxhc') {
+        // The stocks box is a `wDYxhc` container that wraps the stock-price quote
+        // (`data-attrid='Price'`). Require the price node: the bare class gate over-matches
+        // other `wDYxhc` web-answer blocks, and Google dropped the `data-attrid='Company Name'`
+        // span that parse() used to disambiguate, so the price quote is the reliable, unique
+        // (one per box) anchor.
+        if ($node->getAttribute('class') == 'wDYxhc'
+            && $dom->getXpath()->query("descendant::*[@data-attrid='Price']", $node)->length > 0) {
             return self::RULE_MATCH_MATCHED;
         }
 
@@ -24,9 +30,13 @@ class StocksBox implements \Serps\SearchEngine\Google\Parser\ParsingRuleInterfac
 
     public function parse(GoogleDom $dom, \DomElement $node, IndexedResultSet $resultSet, $isMobile = false, array $doNotRemoveSrsltidForDomains = [])
     {
-        $companyNameNode =  $dom->getXpath()->query('descendant::span[contains(concat(\' \', normalize-space(@data-attrid), \' \'), \' Company Name \')]', $node)->item(0);
+        // Google replaced the old `data-attrid='Company Name'` span with the finance
+        // stock-price module, so that selector matches nothing on current SERPs. Anchor
+        // extraction on the unique per-box stock-price quote (`data-attrid='Price'`); its
+        // presence is what makes this a stocks box.
+        $companyNameNode = $dom->getXpath()->query("descendant::*[@data-attrid='Price']", $node)->item(0);
         if (!empty($companyNameNode)) {
-            $companyName = $companyNameNode->textContent;
+            $companyName = trim($companyNameNode->textContent);
             $resultSet->addItem(new BaseResult(NaturalResultType::STOCKS_BOX, [$companyName], $node, $this->hasSerpFeaturePosition));
         }
     }


### PR DESCRIPTION
## Production hotfix — Stocks Box silently undetected

Google replaced the `data-attrid='Company Name'` span with the finance stock-price module, so the parser's `parse()` matched nothing and `stocks_box` was recorded as **absent on every SERP** (`serpf_has_stocks_box` NULL/0 across all shards) even though the widget still renders.

### Fix
Anchor `match()`/`parse()` on the unique per-box stock-price quote (`data-attrid='Price'`) instead of the dead `Company Name` span.

### Validation
Ran the full parser pipeline over real SERPs (google.co.uk desktop, 2026-06-24):
- **17/17** major US/UK stocks detected (apple, microsoft, amazon, alphabet, nvidia, tesla, astrazeneca, barclays, bp, hsbc, shell, glencore, diageo, rolls royce, tesco, aviva, unilever) — exactly **one** price node each, real quotes (USD/GBX), position 1.
- Negative controls correctly excluded: `abrdn` (finance company-info panel, no price quote) and `stock management software` (non-finance).

Tracking: ClickUp [869dvpumz](https://app.clickup.com/t/869dvpumz). The equivalent change is on `self_healing_parser` (with DB-rule plumbing); DB rules 596/597 are synced separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)